### PR TITLE
一部処理の自動化

### DIFF
--- a/pla_control/auto_control.pde
+++ b/pla_control/auto_control.pde
@@ -27,10 +27,15 @@ Servo servo;
 void StartSetup(Arduino arduino) {
   //センサーの数を設定
   Senser_Number = 3;
-  //MaBeeeの数を設定
-  MaBeeeNumber = 3;
   //白幅の終端幅の場所を設定  例:[白黒白黒白]なら3
   WhiteWidthPlace = 3;
+
+  //MaBeeeの数を設定
+  MaBeeeNumber = 3;
+  //プラレール番号の順にMaBeee名と列車名を列挙
+  MaBeeeNames = new String[]{"MaBeee015260", "MaBeee015261", "MaBeeeA08638"};
+  PlaNames = new String[]{"サバンナ号", "金太郎", "SL"};
+  control = new MabeeControl(MaBeeeNames);
 
   //サーボモータの設定(arduino, 接続ポート番号)
   servo = new Servo(arduino, 9);

--- a/pla_control/auto_control.pde
+++ b/pla_control/auto_control.pde
@@ -1,8 +1,24 @@
 import processing.serial.*;
 
-void SetSerialPoat(){
+// シリアルポートへのパスを自動検出
+String findSerialPortPath() {
+  StringList strout = new StringList();
+  StringList strerr = new StringList();
+  int res = shell(strout, strerr, "ls /dev/tty.usbmodem*");
+  if (res != 0) {
+    throw new RuntimeException("Serial port not found.");
+  }
+  String path = strout.get(0);
+  return path;
+}
+
+void SetSerialPort() {
+  // シリアルポートのパス
+  String path = findSerialPortPath();
+
   // arduino = new Arduino(this, "シリアルポート", 通信速度);
-  arduino = new Arduino(this, "/dev/tty.usbmodem143241", 57600);
+  // arduino = new Arduino(this, "/dev/tty.usbmodem143241", 57600);
+  arduino = new Arduino(this, path, 57600);
 }
 
 //サーボモータの数だけ生成

--- a/pla_control/auto_control.pde
+++ b/pla_control/auto_control.pde
@@ -15,7 +15,7 @@ void StartSetup(Arduino arduino) {
   MaBeeeNumber = 3;
   //白幅の終端幅の場所を設定  例:[白黒白黒白]なら3
   WhiteWidthPlace = 3;
-  
+
   //サーボモータの設定(arduino, 接続ポート番号)
   servo = new Servo(arduino, 9);
 }
@@ -30,23 +30,23 @@ void InitPower() {
 /*
     プラレールの速度を変える
     setPow(プラレール番号, 速度 0-100);
-    
+
     プラレールに時間差で速度変更をさせる
     Pla_Timer.add(プラレール番号, 設定時間内の速度, 設定時間後の速度, 設定時間　1秒=120);
-    
+
     サーボモータを回転させる
     回転させるサーボモータクラス.servoRot(回転角度 0-180, 0度に戻る時間 1秒 = 120フレーム)
 */
 
-/* 
+/*
    各センサーがプラレールを検出した時の処理
-   
+
    plaNum = 検出されたプラレール番号
    place = 検出したセンサー番号
 */
 void senser_event(int plaNum, int place){
   println("gousya = " + plaNum + ", place = " + place);
-    
+
   if(place == 0) {
     if(plaNum == 2 ) {
       addPlarailTimer(2, 60, 100, 250);
@@ -57,18 +57,18 @@ void senser_event(int plaNum, int place){
       addPlarailTimer(0, 60, 100, 50);
       addPlarailTimer(1, 50, 90, 60);
     }
-    
+
     if(plaNum == 1) {
       servo.servoRotReset();
     }
-    
+
     if(plaNum == 2) {
       servo.servoRot(90, 240);
       setPow(0, 100);
       addPlarailTimer(1, 60, 90, 120);
     }
   }
-  
+
   if((place == 0 || place == 1) && plaNum != 2) {
     //通信遅延の対策として2回停止信号を送る
     setPow(plaNum, 0);

--- a/pla_control/delegate.pde
+++ b/pla_control/delegate.pde
@@ -6,9 +6,9 @@ void setPow(int plaNum, int val) {
   if (plaNum == 0) {
     control.setDuty(1, val);
   } else if (plaNum == 1) {
-    control.setDuty(2, val); 
+    control.setDuty(2, val);
   } else {
-    control.setDuty(3, val); 
+    control.setDuty(3, val);
   }
 }
 

--- a/pla_control/delegate.pde
+++ b/pla_control/delegate.pde
@@ -3,13 +3,7 @@ import processing.serial.*;
 // plaNum: 0 ~ 2 gousya
 // val: Mabeee's power 0 ~ 100
 void setPow(int plaNum, int val) {
-  if (plaNum == 0) {
-    control.setDuty(1, val);
-  } else if (plaNum == 1) {
-    control.setDuty(2, val);
-  } else {
-    control.setDuty(3, val);
-  }
+  control.setDuty(plaNum, val);
 }
 
 void addPlarailTimer(int plaNum, int startSpd, int endSpd, int time) {

--- a/pla_control/pla_control.pde
+++ b/pla_control/pla_control.pde
@@ -19,49 +19,49 @@ void setup() {
   size(1600,800);
   frameRate(120);
   background(#000000);
-  
+
   SetSerialPoat();
   StartSetup(arduino);
-  
+
   sensors = new Sensor[Senser_Number];
-  
+
   //センサーの数だけ生成
   for(int i = 0; i < Senser_Number; i++) {
     sensors[i] = new Sensor(arduino, i);
   }
-  
+
   //メッセージに空文字を挿入
   for(int i = 0; i < msg.length; i++) {
     msg[i] = "";
   }
-  
+
   initPla();
 }
 
 void draw() {
   background(#000000);
   textSize(13);
-  
+
   fill(#FFFFFF);
-  
+
   for (Sensor s: sensors) {
     s.update();
   }
-  
+
   for(int i = Pla_Timer.size()-1; i >= 0; i--) {
     Plarail_Timer pla_Timer = Pla_Timer.get(i);
     pla_Timer.TimerCont();
     if(pla_Timer.endTime == -1) Pla_Timer.remove(i);
   }
-  
+
   //グラフ画面に文字を表示
   textSize(20);
   for(int i = 0; i < msg.length; i++) {
     //文字列に"error"が含まれる時、文字を赤に
-    String[] m1 = match(msg[i], "error");    
+    String[] m1 = match(msg[i], "error");
     if (m1 != null) fill(#FF0000); //match
     else fill(#FFFFFF);
-    
+
     text(msg[i], 50, 320 - 30*i);
     fill(#FFFFFF);
   }
@@ -70,10 +70,10 @@ void draw() {
 
 //Mabeeeの接続設定 (詳しくはpla_utils内のMabeeControlクラスを参照)
 void initPla() {
-  
+
   control.init();
   println("finish init");
-  
+
   control.scan();
   println("finish scan");
   control.waitDevice();
@@ -86,7 +86,7 @@ void initPla() {
     control.makeReady(i);
   }
   println("ready");
-  
+
   InitPower();
 }
 

--- a/pla_control/pla_control.pde
+++ b/pla_control/pla_control.pde
@@ -5,12 +5,15 @@ import processing.serial.*;
 import cc.arduino.*;
 import org.firmata.*;
 import http.requests.*;
+
 int Senser_Number = 3;
 int WhiteWidthPlace = 3;
 int MaBeeeNumber = 3;
+String[] MaBeeeNames;
+String[] PlaNames;
+MabeeControl control;
 Sensor[] sensors;
 Arduino arduino;
-MabeeControl control = new MabeeControl();
 String msg[] = new String[9];
 
 ArrayList<Plarail_Timer> Pla_Timer = new ArrayList<Plarail_Timer>();
@@ -20,7 +23,7 @@ void setup() {
   frameRate(120);
   background(#000000);
 
-  SetSerialPoat();
+  SetSerialPort();
   StartSetup(arduino);
 
   sensors = new Sensor[Senser_Number];
@@ -76,15 +79,11 @@ void initPla() {
 
   control.scan();
   println("finish scan");
-  control.waitDevice();
+  control.waitAndSetDeviceAll();
   println("check device");
-  for(int i = 1; i <= MaBeeeNumber; i++) {
-    control.connect(i);
-  }
+  control.connectAll();
   println("connected");
-  for(int i = 1; i <= MaBeeeNumber; i++) {
-    control.makeReady(i);
-  }
+  control.makeReadyAll();
   println("ready");
 
   InitPower();
@@ -98,7 +97,7 @@ void initPla() {
   stop_plaを起動させて止める
 */
 void dispose() {
-  for(int i = 1; i <= MaBeeeNumber; i++) {
+  for(int i = 0; i < MaBeeeNumber; i++) {
     control.setDuty(i, 0);
     control.disconnect(i);
   }

--- a/pla_control/pla_timer.pde
+++ b/pla_control/pla_timer.pde
@@ -2,7 +2,7 @@ class Plarail_Timer {
   int plaNum;
   int f_speed;
   int e_speed;
-  
+
   int count;
   int endTime;
   Plarail_Timer(int Num, int firstSpeed, int endSpeed, int Timer) {
@@ -13,7 +13,7 @@ class Plarail_Timer {
     this.endTime = Timer;
     this.count = 0;
   }
-  
+
   void TimerCont() {
     if(this.count == this.endTime) {
       setPow(this.plaNum, this.e_speed);
@@ -21,5 +21,5 @@ class Plarail_Timer {
     }
     this.count++;
   }
-  
+
 }

--- a/pla_control/pla_utils.pde
+++ b/pla_control/pla_utils.pde
@@ -16,11 +16,11 @@ class Sensor {
   int[] blackWidths = new int[1000];
   int whiteIndex = 0;
   int blackIndex = 0;
-  
+
   boolean blackRead = false;
   boolean checkCode = false;
   int plaCode = 0;
-  
+
   Sensor(Arduino arduino, int port) {
     this.arduino = arduino;
     this.port = port;
@@ -37,24 +37,24 @@ class Sensor {
       tmpC = #0000FF;
       break;
     }
-    
+
     graph = new MyGraph(2, tmpC);
   }
-  
+
   void update() {
     int v = arduino.analogRead(port);
     int rV = round(map(v, 800, 1024, height * 0.1, height * 0.9));
-    
+
     boolean whiteCond = rV < 500;
 
     graph.update(whiteCond ? 300:100);
     //白帯を検出した時, whiteCountを増やす
     if (whiteCond) {
       whiteCount++;
-      
+
       //whiteIndex(白帯の検出数)が0の時, blackCountを0にする
       if(whiteIndex == 0) blackCount = 0;
-      
+
       /*
         blackReadが真の時, blackWidths(黒帯の検出幅配列)の要素[blackIndex(黒帯検出数)]にblackCountを代入
         blackIndexを1増やしcheckCodeを真にしblackReadを負にする
@@ -68,10 +68,10 @@ class Sensor {
         blackCount = 0;
         blackIndex++;
       }
-      
+
     } else {
       //黒帯を検出した時, blackCountを増やす
-      
+
       //もし黒帯が一定時間続いた時
       if (blackCount > frameRate * 0.35) {
         /*
@@ -90,7 +90,7 @@ class Sensor {
           checkCode = false;
         }
       }
-      
+
       /*
         whiteCountが1以上(白帯が検出されている)の時, whiteWidths(白帯の検出幅配列)の要素[whiteIndex(白帯検出数)]にwhiteCountを代入
         whiteIndexを1増やしblackReadを真にする
@@ -105,7 +105,7 @@ class Sensor {
       }
       blackCount++;
     }
-    
+
     int bitSet;
     /*
       checkCodeが真の時
@@ -121,7 +121,7 @@ class Sensor {
       }
       checkCode = false;
     }
-    
+
     /*
       白幅の終端幅の場所を設定  例:[黒白黒白]なら2
       whiteIndex(白帯検出数)が終端白帯の位置の時, event()を呼び出す
@@ -153,7 +153,7 @@ enum State {
 
 class MabeeControl {
   State state = State.init;
- 
+
   boolean existDevice() {
     try {
       JSONObject data = getJSON("devices");
@@ -161,8 +161,8 @@ class MabeeControl {
     } catch (Exception e) {}
     return false;
   }
-  
-  
+
+
   void init() {
     boolean result = false;
     do {
@@ -171,11 +171,11 @@ class MabeeControl {
     } while(!result);
     state = State.poweredOn;
   }
-  
+
   void scan() {
     boolean result = false;
     do {
-      //print("."); 
+      //print(".");
       GetRequest get = new GetRequest("http://localhost:11111/" + "scan/start");
       get.send();
       delay(100);
@@ -183,14 +183,14 @@ class MabeeControl {
     } while(!result);
     state = State.scaned;
   }
-  
+
   void waitDevice() {
     while(!existDevice()){
       //print(".");
     }
     state = State.connected;
   }
-  
+
   void connect(int id) {
     boolean result = false;
     do {
@@ -202,7 +202,7 @@ class MabeeControl {
     } while(!result);
     state = State.connected;
   }
-  
+
   void makeReady(int id) {
     GetRequest get = new GetRequest("http://localhost:11111/devices/" + id +"/connect");
     get.send();
@@ -212,29 +212,29 @@ class MabeeControl {
     delay(100);
     state = State.ready;
   }
-  
+
   void setDuty(int id, int val) {
     GetRequest get = new GetRequest("http://localhost:11111/devices/" + id + "/set?pwm_duty=" + val);
     get.send();
     //delay(50);
   }
-  
+
   void disconnect(int id) {
     GetRequest get = new GetRequest("http://localhost:11111/devices/" + id + "/disconnect");
     get.send();
     delay(100);
     state = State.init;
   }
-  
+
   JSONObject getJSON(String url) throws Exception {
     GetRequest get = new GetRequest("http://localhost:11111/" + url);
     get.send();
     return parseJSONObject(get.getContent());
   }
-  
+
   boolean validRequestString(String url, String key, String value) {
     try {
-      
+
       //println(getJSON(url).getString(key));
       return getJSON(url).getString(key).equals(value);
     } catch (Exception e) {
@@ -242,7 +242,7 @@ class MabeeControl {
     }
     return false;
   }
-  
+
   boolean validRequestBoolean(String url, String key, Boolean value) {
     try {
       return getJSON(url).getBoolean(key) == value;
@@ -251,8 +251,8 @@ class MabeeControl {
     }
     return false;
   }
-  
-  
+
+
 }
 
 class MyGraph {
@@ -264,18 +264,18 @@ class MyGraph {
     this.step = step;
     this.graphColor = graphColor;
   }
-  
+
   void update(int val) {
     addShiftArray(vals, val);
     stroke(graphColor);
     drawArray(vals);
   }
-  
+
   private void addShiftArray(int[] array, int val) {
     System.arraycopy(array, 0, array, 1, array.length - 1);
     array[0] = val;
   }
-  
+
   private void drawArray(int[] array) {
     pushMatrix();
     translate(0, height);
@@ -284,7 +284,7 @@ class MyGraph {
     for(int i = 0; i < array.length - 1; i++) {
       line(i * step, array[i], (i + 1) * step, array[i + 1]);
     }
-  
+
     popMatrix();
   }
 }

--- a/pla_control/servo_utils.pde
+++ b/pla_control/servo_utils.pde
@@ -7,19 +7,19 @@ class Servo{
     int time;
     int count;
     boolean rot;
-    
+
     Servo(Arduino arduino, int port) {
       this.arduino = arduino;
       this.port = port;
       this.time = 0;
       this.count = 0;
       this.rot = false;
-      
+
       arduino.pinMode(this.port, Arduino.SERVO);
       arduino.servoWrite(this.port, 0);
       println("servo port:" + this.port+ " reset");
     }
-    
+
     void update() {
       if (rot) {
         if(this.time == this.count) {
@@ -28,7 +28,7 @@ class Servo{
         this.count++;
       }
     }
-   
+
     /*
       angle: 0-180, time: framerate = 120
       このメソッドが呼ばれた時, update()のcountがスタート
@@ -40,7 +40,7 @@ class Servo{
       this.count = 0;
       arduino.servoWrite(this.port, angle);
     }
-    
+
     //サーボモータの角度を0度にするメソッド
     void servoRotReset() {
       this.rot = false;

--- a/stop_pla/stop_pla.pde
+++ b/stop_pla/stop_pla.pde
@@ -2,7 +2,7 @@ import http.requests.*;
 
 
 class MabeeControl {
- 
+
   boolean existDevice() {
     try {
       JSONObject data = getJSON("devices");
@@ -10,8 +10,8 @@ class MabeeControl {
     } catch (Exception e) {}
     return false;
   }
-  
-  
+
+
   void init() {
     boolean result = false;
     do {
@@ -20,24 +20,24 @@ class MabeeControl {
       result = validRequestString("", "state", "PoweredOn");
     } while(!result);
   }
-  
+
   void scan() {
     boolean result = false;
     do {
-      print("."); 
+      print(".");
       GetRequest get = new GetRequest("http://localhost:11111/" + "scan/start");
       get.send();
       delay(100);
       result = validRequestBoolean("scan/", "scan", true);
     } while(!result);
   }
-  
+
   void waitDevice() {
     while(!existDevice()){
       print(".");
     }
   }
-  
+
   void connect(int id) {
     boolean result = false;
     do {
@@ -48,7 +48,7 @@ class MabeeControl {
       result = validRequestString("devices/" + id +"/", "state", "Connected");
     } while(!result);
   }
-  
+
   void makeReady(int id) {
     GetRequest get = new GetRequest("http://localhost:11111/devices/" + id +"/connect");
     get.send();
@@ -57,28 +57,28 @@ class MabeeControl {
     get.send();
     delay(100);
   }
-  
+
   void setDuty(int id, int val) {
     GetRequest get = new GetRequest("http://localhost:11111/devices/" + id + "/set?pwm_duty=" + val);
     get.send();
     delay(100);
   }
-  
+
   void disconnect(int id) {
     GetRequest get = new GetRequest("http://localhost:11111/devices/" + id + "/disconnect");
     get.send();
     delay(100);
   }
-  
+
   JSONObject getJSON(String url) throws Exception {
     GetRequest get = new GetRequest("http://localhost:11111/" + url);
     get.send();
     return parseJSONObject(get.getContent());
   }
-  
+
   boolean validRequestString(String url, String key, String value) {
     try {
-      
+
       println(getJSON(url).getString(key));
       return getJSON(url).getString(key).equals(value);
     } catch (Exception e) {
@@ -86,7 +86,7 @@ class MabeeControl {
     }
     return false;
   }
-  
+
   boolean validRequestBoolean(String url, String key, Boolean value) {
     try {
       return getJSON(url).getBoolean(key) == value;
@@ -95,7 +95,7 @@ class MabeeControl {
     }
     return false;
   }
-  
+
 }
 
 void setup() {


### PR DESCRIPTION
動的な設定値を自動で設定する機能を2つ実装しました。

## シリアルポートのパス指定を自動化
Arduinoのシリアルポートのパスは、ArduinoをUSB接続するたびに変化します。

auto_control.pde にシリアルポートへのパスを自動検出するメソッドを定義しました。
このメソッドは、`ls /dev/tty.usbmodem*` をシェルで叩いて得られる結果の先頭文字列を返します。

SetSerialPort メソッドからこのメソッドを呼び出し、自動的にパスを設定します。

## プラレール番号で MaBeee を制御する機能の追加
MaBeee の制御には個体を識別する MaBeee ID の指定が必要です。
この MaBeee ID は恐らく MaBeeeMacApp が独自に設定したものであり、MaBeee を検出するたびに変化します。
一方、[wiki](https://github.com/novars-jp/MaBeeeMacApp/wiki/devices-:id) で「デバイスの名前」と説明されている name フィールドは恐らく固定値です。（製造番号？）

この値（MaBeee Name）を介して、プラレール番号 --> MaBeee Name --> MaBeee ID のように変換する処理を追加しました。
プラレール番号 --> MaBeee Name は固定であり、利用者が設定します。
MaBeee Name --> MaBeee ID は変化しますが、プログラムが自動で設定します。
これにより、プラレール番号で MaBeee を制御することができるようになります。

具体的な処理の流れは以下のとおりです。
1. auto_control.pde の StartSetup メソッドで、MaBeee Name とプラレール番号を紐付けしたデータ MaBeeeNames（添字がプラレール番号の配列）を予め設定値として作成しておきます。
2. MabeeControl クラスのコンストラクタで、MaBeee Name をプラレール番号に変換するデータ mabeeeName2plaNum（key が MaBeee Name の Map）を作成します。
3. スキャン時には MaBeee Name と MaBeee ID がわかるので、先述のデータを用いてプラレール番号と MaBeee ID を紐付けしたデータ plaNum2mabeeeId（添字がプラレール番号の配列）を作成します。（MabeeControl クラス waitAndSetDeviceAll メソッド）